### PR TITLE
automatically translate occurrences and refresh to fatigue_check annotations

### DIFF
--- a/lib/sensu/translator/translations.rb
+++ b/lib/sensu/translator/translations.rb
@@ -45,6 +45,8 @@ module Sensu
         unless object.empty?
           annotations["sensu.io.json_attributes".to_sym] = Sensu::JSON.dump(object)
         end
+        annotations["fatigue_check/occurrences"] = object[:occurrences].to_s if object[:occurrences]
+        annotations["fatigue_check/interval"] = object[:refresh].to_s if object[:refresh]
         go_spec(:check, check, namespace, name, {}, annotations)
       end
 

--- a/spec/sensu/translator/translations_spec.rb
+++ b/spec/sensu/translator/translations_spec.rb
@@ -72,4 +72,16 @@ describe "Sensu::Translator::Translations" do
     result = translate_check(@check, @namespace, "spec")
     expect(result[:metadata][:annotations]["sensu.io.json_attributes".to_sym]).to eq('{"foo":"bar"}')
   end
+
+  it "can add fatigue_check/occurrance annotation when occurrences is present" do
+    @check[:occurrences] = 10
+    result = translate_check(@check, @namespace, "spec")
+    expect(result[:metadata][:annotations]["fatigue_check/occurrences"]).to eq("10")
+  end
+
+  it "can add fatigue_check/interval annotation when refresh is present" do
+    @check[:refresh] = 3600
+    result = translate_check(@check, @namespace, "spec")
+    expect(result[:metadata][:annotations]["fatigue_check/interval"]).to eq("3600")
+  end
 end


### PR DESCRIPTION
As Sensu Go does not provide a built-in filter similar to Sensu 1.x's occurrences filter, we need to help folks migrating to 1.x configure their checks to work with a similar filter.

The changes in this PR update the translator to automatically convert occurrences and refresh attributes into the corresponding annotations honored by https://github.com/nixwiz/sensu-go-fatigue-check-filter/