### PR TITLE
remove logic for migrating check ttl_status

### DIFF
--- a/lib/sensu/translator/translations.rb
+++ b/lib/sensu/translator/translations.rb
@@ -37,7 +37,6 @@ module Sensu
         check[:stdin] = object.delete(:stdin) if object[:stdin]
         check[:timeout] = object.delete(:timeout) if object[:timeout]
         check[:ttl] = object.delete(:ttl) if object[:ttl]
-        check[:ttl_status] = object.delete(:ttl_status) if object[:ttl_status]
         check[:low_flap_threshold] = object.delete(:low_flap_threshold) if object[:low_flap_threshold]
         check[:high_flap_threshold] = object.delete(:high_flap_threshold) if object[:high_flap_threshold]
         # TODO: subdue, hooks


### PR DESCRIPTION
Sensu Go does not have support for ttl_status as implemented in Sensu 1.x.
Until support for ttl_status is added, it is not a valid Sensu Go check attribute.

Closes #4